### PR TITLE
M: Round corner of image, when there is a cornerRadius set

### DIFF
--- a/Sources/DynamicBlurView/DynamicBlurView.swift
+++ b/Sources/DynamicBlurView/DynamicBlurView.swift
@@ -125,10 +125,12 @@ open class DynamicBlurView: UIView {
 extension DynamicBlurView {
     open override func display(_ layer: CALayer) {
         if let blurredImage = (staticImage ?? currentImage()).flatMap(imageBlurred) {
-            blurLayer.draw(blurredImage)
+            let usedImage = (layer.cornerRadius > 0 ? blurredImage.withRoundedCorners(radius: layer.cornerRadius) : blurredImage) ?? UIImage()
+                
+            blurLayer.draw(usedImage)
 
             if isDeepRendering {
-                blurLayer.contentsRect = relativeLayerRect.rectangle(blurredImage.size)
+                blurLayer.contentsRect = relativeLayerRect.rectangle(usedImage.size)
             }
         }
     }

--- a/Sources/DynamicBlurView/UIImage+Blur.swift
+++ b/Sources/DynamicBlurView/UIImage+Blur.swift
@@ -28,3 +28,23 @@ public extension UIImage {
         }
     }
 }
+
+extension UIImage {
+    // image with rounded corners
+    public func withRoundedCorners(radius: CGFloat? = nil) -> UIImage? {
+        let maxRadius = min(size.width, size.height) / 2
+        let cornerRadius: CGFloat
+        if let radius = radius, radius > 0 && radius <= maxRadius {
+            cornerRadius = radius
+        } else {
+            cornerRadius = maxRadius
+        }
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        let rect = CGRect(origin: .zero, size: size)
+        UIBezierPath(roundedRect: rect, cornerRadius: cornerRadius).addClip()
+        draw(in: rect)
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
+    }
+}


### PR DESCRIPTION
**Problem:**
When a cornerRadius is set to the dynamicBlurView, then the provided image has no rounded corner and is visible next to the rounded corner.

**Solution:**
Automatically creates rounded corners of the image so that it doesn't clash with the rounded corners anymore.